### PR TITLE
Harden filename handling and test execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ EXPOSE 4999
 
 ENV NAME Video downloader
 
-#CMD ["/bin/sh", "-c", "pip install -U yt-dlp && python app.py"]
+#CMD ["/bin/sh", "-c", "pip install -U yt-dlp && python -m app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add ffmpeg
+RUN apk add ffmpeg nodejs
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,36 @@ Simple, self-hosted web-based video downloader using the popular tool *wink wink
 ![Screenshot](assets/screenshot.png)
 
 It attempts to download h264 videos from the popular online video sites so they're readily available to play using any browser without any conversion and workarounds.
+
+## Configuration
+
+The application stores downloaded videos in a directory defined by the
+`VIDEOS_DIR` environment variable. By default this is `videos/` relative to the
+project root. When running via Docker Compose the folder is mounted into both
+the Flask container and Nginx so the files can be served directly. Set this
+variable before running the app to customize where downloads are stored:
+
+```bash
+export VIDEOS_DIR=/path/to/videos
+python -m app
+```
+
+## Running locally
+
+Install the dependencies and launch the development server:
+
+```bash
+pip install -r app/requirements.txt
+python -m app
+```
+
+## Tests
+
+Basic tests for the helper functions can be executed with `pytest`:
+
+```bash
+pytest
+```
+
+These tests cover utilities such as safe filename generation to ensure filenames
+remain cross platform friendly and easily URL encoded.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,17 @@
+import os
+from flask import Flask
+from flask_socketio import SocketIO
+from flask_cors import CORS
+
+socketio = SocketIO(cors_allowed_origins="*")
+
+
+def create_app():
+    app = Flask(__name__)
+    CORS(app)
+    app.config['VIDEOS_DIR'] = os.environ.get('VIDEOS_DIR', 'videos')
+
+    from . import views
+    app.register_blueprint(views.bp)
+    socketio.init_app(app)
+    return app

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,10 @@
+import os
+from . import create_app, socketio
+
+app = create_app()
+
+if __name__ == '__main__':
+    video_dir = app.config['VIDEOS_DIR']
+    if not os.path.exists(video_dir):
+        os.makedirs(video_dir)
+    socketio.run(app, host='0.0.0.0', port=4999, allow_unsafe_werkzeug=True)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.3
 yt-dlp
 flask_socketio
 flask_cors
+pytest

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,5 @@
 Flask==3.0.3
-yt-dlp
+yt-dlp[default]
 flask_socketio
 flask_cors
 pytest

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -121,7 +121,7 @@
     <h2>Downloaded files</h2>
     {% for video_file in video_files %}
     <div class="links">
-        <a class='video-link' href="{{ url_for('play', file=video_file['original_filename']) }}">{{ video_file['sanitized_title'] }}</a>
+        <a class='video-link' href="{{ url_for('main.play', file=video_file['original_filename']) }}">{{ video_file['sanitized_title'] }}</a>
         <button class="delete_video" data-video="{{ video_file['original_filename'] }}">Delete</button>
     </div>
     {% endfor %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,29 @@
+import os
+from flask import current_app
+from werkzeug.utils import secure_filename
+
+VIDEO_EXTENSION = ".mp4"
+
+
+def video_directory():
+    return current_app.config['VIDEOS_DIR']
+
+
+def list_mp4_video_files():
+    directory = video_directory()
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+    files = [f for f in os.listdir(directory) if f.endswith(VIDEO_EXTENSION)]
+    update_times = [os.path.getmtime(os.path.join(directory, f)) for f in files]
+    return [f for _, f in sorted(zip(update_times, files), reverse=True)]
+
+
+def format_filename(filename):
+    return filename.replace('_', ' ').replace(VIDEO_EXTENSION, '')
+
+
+def safe_filename(title):
+    base = secure_filename(title) or 'video'
+    if not base.lower().endswith(VIDEO_EXTENSION):
+        base = f"{base}{VIDEO_EXTENSION}"
+    return base

--- a/app/views.py
+++ b/app/views.py
@@ -84,6 +84,7 @@ def download_video(url):
         'writesubtitles': True,
         'writethumbnail': True,
         'updatetime': False,
+        'js_runtimes': ['node'],
         'progress_hooks': [create_progress_hook(url)],
     }
 

--- a/app/views.py
+++ b/app/views.py
@@ -1,19 +1,18 @@
-from flask import Flask, request, render_template, jsonify
-from flask_socketio import SocketIO, emit
-from flask_cors import CORS
-import yt_dlp
 import os
 import threading
+import yt_dlp
 
-VIDEO_EXTENSION = ".mp4"
+from flask import Blueprint, request, render_template, jsonify
+
+from . import socketio
+from .utils import list_mp4_video_files, format_filename, safe_filename, video_directory, VIDEO_EXTENSION
+
+bp = Blueprint('main', __name__)
 
 downloads_in_progress = {}
 
-app = Flask(__name__)
-CORS(app)
-socketio = SocketIO(app, cors_allowed_origins="*")
 
-@app.route('/', methods=['GET'])
+@bp.route('/', methods=['GET'])
 def index():
     video_files = list_mp4_video_files()
     formatted_video_files = [
@@ -24,38 +23,42 @@ def index():
     ]
     return render_template('index.html', video_files=formatted_video_files)
 
-@app.route('/downloads', methods=['GET'])
+
+@bp.route('/downloads', methods=['GET'])
 def downloads():
     return jsonify(downloads_in_progress)
 
-@app.route('/download', methods=['POST'])
+
+@bp.route('/download', methods=['POST'])
 def download():
-    data = request.get_json()
-    video_url = data['url']
+    data = request.get_json(silent=True) or {}
+    video_url = data.get('url')
+    if not video_url:
+        return jsonify({'error': 'url is required'}), 400
+
     threading.Thread(target=download_video, args=(video_url,)).start()
     return jsonify({'status': 'started'})
 
-def list_mp4_video_files():
-    files = [f for f in os.listdir('videos') if f.endswith(VIDEO_EXTENSION)]
-    update_times = [os.path.getmtime(os.path.join('videos', f)) for f in files]
-    files = [f for _, f in sorted(zip(update_times, files), reverse=True)]
-    return files
-
-def format_filename(filename):
-    return filename.replace('_', ' ').replace(VIDEO_EXTENSION, '')
 
 def yt_progress_hook(url, d):
-    socketio.emit('download_progress', {'url': url, 'status': d['status'], 'progress': d.get('_percent_str', '0%')})
+    socketio.emit('download_progress', {
+        'url': url,
+        'status': d['status'],
+        'progress': d.get('_percent_str', '0%')
+    })
+
 
 def create_progress_hook(url):
     def progress_hook(d):
         yt_progress_hook(url, d)
     return progress_hook
 
+
 def download_video(url):
+    directory = video_directory()
     ydl_opts = {
-        'outtmpl': 'videos/%(id)s.%(ext)s',
-        'format': 'bv[ext=mp4][vcodec~=\'^((he|a)vc|h26[45])\']+ba[ext=m4a]',
+        'outtmpl': os.path.join(directory, '%(id)s.%(ext)s'),
+        'format': "bv[ext=mp4][vcodec~='^((he|a)vc|h26[45])']+ba[ext=m4a]",
         'postprocessors': [
             {
                 'already_have_subtitle': False,
@@ -65,9 +68,11 @@ def download_video(url):
                 'add_chapters': True,
                 'add_infojson': 'if_exists',
                 'add_metadata': True,
-                'key': 'FFmpegMetadata'},
+                'key': 'FFmpegMetadata'
+            },
             {
-                'already_have_thumbnail': False, 'key': 'EmbedThumbnail'
+                'already_have_thumbnail': False,
+                'key': 'EmbedThumbnail'
             },
             {
                 'key': 'FFmpegConcat',
@@ -89,36 +94,40 @@ def download_video(url):
             video_id = info_dict.get('id', 'video')
             video_title = info_dict.get('title', 'video')
             video_filename = f'{video_id}{VIDEO_EXTENSION}'
-            safe_filename = f'{video_title}{VIDEO_EXTENSION}'.replace(':', '_').replace('?', '_').replace(' ', '_').replace('#', '_').replace('/', '_')
+            safe_name = safe_filename(video_title)
             ydl.download([url])
-            os.rename('videos/' + video_filename, 'videos/' + safe_filename)
+            os.rename(os.path.join(directory, video_filename), os.path.join(directory, safe_name))
             downloads_in_progress[url] = 'completed'
             socketio.emit('download_complete', {'url': url})
     except Exception as e:
         downloads_in_progress[url] = f'error {str(e)}'
         socketio.emit('download_error', {'url': url, 'error': str(e)})
 
-@app.route('/play', methods=['GET'])
+
+@bp.route('/play', methods=['GET'])
 def play():
     filename = request.args.get('file', default=None, type=str)
     formatted_video_file = {
-            'original_filename': filename,
-            'sanitized_title': format_filename(filename)
+        'original_filename': filename,
+        'sanitized_title': format_filename(filename)
     }
     return render_template('play.html', video_file=formatted_video_file)
 
-@app.route('/delete', methods=['POST', 'DELETE'])
+
+@bp.route('/delete', methods=['POST', 'DELETE'])
 def delete():
-    filename = request.args.get('file', default=None, type=str)
-    filename = os.path.normpath('videos/{filename}'.format(filename=filename))
-    if filename.startswith('videos/'):
-        os.remove(filename)
-        return filename, 200
-    return 'invalid file', 400
+    requested_name = request.args.get('file', default=None, type=str)
+    if not requested_name:
+        return 'file is required', 400
 
-if __name__ == '__main__':
-    if not os.path.exists('videos'):
-        os.makedirs('videos')
+    videos_root = os.path.realpath(video_directory())
+    resolved_file = os.path.realpath(os.path.join(videos_root, requested_name))
 
-    socketio.run(app, host='0.0.0.0', port=4999, allow_unsafe_werkzeug=True)
-    
+    if os.path.commonpath([videos_root, resolved_file]) != videos_root:
+        return 'invalid file', 400
+
+    if not os.path.exists(resolved_file):
+        return 'file not found', 404
+
+    os.remove(resolved_file)
+    return requested_name, 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,11 @@ services:
       - "4999:4999"
     environment:
       FLASK_ENV: production
+      VIDEOS_DIR: /app/videos
     volumes:
       - ./app:/app
       - ${VIDEOS_DIR:-./videos}:/app/videos
-    command: sh -c 'pip install -U yt-dlp && python app.py'
+    command: sh -c 'pip install -U yt-dlp && python -m app'
   nginx:
     build:
       context: ./nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./app:/app
       - ${VIDEOS_DIR:-./videos}:/app/videos
-    command: sh -c 'pip install -U yt-dlp && python -m app'
+    command: sh -c 'pip install -U "yt-dlp[default]" && python -m app'
   nginx:
     build:
       context: ./nginx

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,43 @@
+import os
+from app import create_app
+from app.utils import list_mp4_video_files, safe_filename, format_filename, VIDEO_EXTENSION
+
+
+def test_safe_filename_simple(tmp_path):
+    app = create_app()
+    with app.app_context():
+        name = safe_filename('Test: Video?')
+    assert name == f'Test_Video{VIDEO_EXTENSION}'
+    assert ':' not in name and '?' not in name and ' ' not in name
+
+
+def test_safe_filename_fallback_when_name_is_empty():
+    app = create_app()
+    with app.app_context():
+        name = safe_filename('////')
+    assert name == f'video{VIDEO_EXTENSION}'
+
+
+def test_list_mp4_video_files_sorted(tmp_path):
+    (tmp_path / 'one.mp4').write_text('1')
+    (tmp_path / 'two.mp4').write_text('2')
+    os.utime(tmp_path / 'one.mp4', (1, 1))
+    app = create_app()
+    app.config['VIDEOS_DIR'] = str(tmp_path)
+    with app.app_context():
+        files = list_mp4_video_files()
+    assert files == ['two.mp4', 'one.mp4']
+
+
+def test_format_filename():
+    assert format_filename('My_Video.mp4') == 'My Video'
+
+
+def test_delete_blocks_path_traversal(tmp_path):
+    app = create_app()
+    app.config['VIDEOS_DIR'] = str(tmp_path)
+    client = app.test_client()
+
+    response = client.post('/delete?file=../etc/passwd')
+
+    assert response.status_code == 400


### PR DESCRIPTION
### Motivation
- Improve reliability and maintainability around where videos are stored and how filenames are handled to avoid runtime errors and unsafe filesystem operations.
- Prevent invalid requests from causing server-side failures by validating input to the `/download` endpoint and returning clear HTTP errors.
- Protect against path traversal in file deletion and make filename sanitization resilient when the sanitized name would otherwise be empty.

### Description
- Add application factory and socket initialization in `app/__init__.py` (`create_app`) and new runnable entrypoint `app/__main__.py` so the app can be executed with `python -m app`.
- Move the Flask logic into a Blueprint in `app/views.py` (renamed from `app/app.py`) and register it from the factory.
- Centralize video path handling in `app/utils.py` with `video_directory`, `list_mp4_video_files`, `format_filename`, and a hardened `safe_filename` that falls back to `video.mp4` when sanitization yields an empty name.
- Validate `/download` requests to return `400` when `url` is missing, and harden `/delete` to resolve real paths and block path traversal while returning `400`/`404` for invalid or missing targets.
- Update `README.md` to document the `VIDEOS_DIR` env var and running instructions, update `docker-compose.yml` to pass `VIDEOS_DIR` and use `python -m app`, and adjust the Dockerfile comment to match.
- Add `tests/test_utils.py` covering `safe_filename` (including empty fallback), `list_mp4_video_files` ordering, `format_filename`, and a test that `/delete` rejects path traversal, and add `pytest.ini` so `pytest` can import the `app` package.

### Testing
- Ran the test suite with `pytest -q` and all tests passed: `5 passed in 0.31s`.
- Also executed `python -m pytest -q` to validate package execution discoverability and it completed successfully.
