### PR TITLE
Add Node.js runtime support for yt-dlp video downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add ffmpeg
+RUN apk add ffmpeg nodejs
 
 WORKDIR /app
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,5 @@
 Flask==3.0.3
-yt-dlp
+yt-dlp[default]
 flask_socketio
 flask_cors
 pytest

--- a/app/views.py
+++ b/app/views.py
@@ -84,6 +84,7 @@ def download_video(url):
         'writesubtitles': True,
         'writethumbnail': True,
         'updatetime': False,
+        'js_runtimes': ['node'],
         'progress_hooks': [create_progress_hook(url)],
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./app:/app
       - ${VIDEOS_DIR:-./videos}:/app/videos
-    command: sh -c 'pip install -U yt-dlp && python -m app'
+    command: sh -c 'pip install -U "yt-dlp[default]" && python -m app'
   nginx:
     build:
       context: ./nginx


### PR DESCRIPTION
## Summary
This PR adds Node.js runtime support to enable yt-dlp to handle videos that require JavaScript execution for content extraction.

## Key Changes
- **Docker setup**: Added `nodejs` to the Alpine Linux packages in the Dockerfile to provide the JavaScript runtime environment
- **Dependencies**: Updated `yt-dlp` to use the `[default]` extras group in both `requirements.txt` and `docker-compose.yml` to include optional dependencies
- **Video download configuration**: Added `'js_runtimes': ['node']` to the yt-dlp options in `app/views.py` to explicitly enable Node.js as the JavaScript runtime for video processing

## Implementation Details
The changes ensure that yt-dlp can properly handle videos protected by JavaScript-based content delivery mechanisms. By specifying Node.js as the JavaScript runtime, the application can now extract video information from sites that require JavaScript execution to generate download URLs or metadata.

https://claude.ai/code/session_01A45tGNuPaBY6Y7iutjBaxc